### PR TITLE
Add values for DoT and DoH transport protocols

### DIFF
--- a/dnsmessage.proto
+++ b/dnsmessage.proto
@@ -41,6 +41,8 @@ message PBDNSMessage {
     TCP = 2;                                    // Transmission Control Protocol (RFC 793)
     DOT = 3;                                    // DNS over TLS (RFC 7858)
     DOH = 4;                                    // DNS over HTTPS (RFC 8484)
+    DNSCryptUDP = 5;                            // DNSCrypt over UDP (https://dnscrypt.info/protocol)
+    DNSCryptTCP = 6;                            // DNSCrypt over TCP (https://dnscrypt.info/protocol)
   }
   enum PolicyType {
     UNKNOWN = 1;                                // No RPZ policy applied, or unknown type


### PR DESCRIPTION
It makes sense to be able to know whether the protocol used to transport queries and responses is a secure one, and which one.
I kept the exact same values than the ones used by dnstap, but I wonder if it would not make sense to support DNSCrypt UDP and TCP  as well.