### PR TITLE
uint16 actually does not exist in protobuf, use uint32

### DIFF
--- a/dnsmessage.proto
+++ b/dnsmessage.proto
@@ -188,7 +188,7 @@ message PBDNSMessage {
   optional uint64 workerId = 25;                // Thread id
   optional bool packetCacheHit = 26;            // Was it a packet cache hit?
   optional uint32 outgoingQueries = 27;         // Number of outgoing queries used to answer the query
-  optional uint16 headerFlags = 28;             // Flags field in wire format
+  optional uint32 headerFlags = 28;             // Flags field in wire format
   optional uint32 ednsVersion = 29;             // EDNS version and flags in wire format, see https://www.rfc-editor.org/rfc/rfc6891.html#section-6.1.3
 }
 


### PR DESCRIPTION
uint16 does not exist in protobuf world.